### PR TITLE
1.10.0 - Added Name Filtering WIP

### DIFF
--- a/CityInfoAPI/CityInfoAPI.Data/Repositories/CityInfoMemoryDataStore.cs
+++ b/CityInfoAPI/CityInfoAPI.Data/Repositories/CityInfoMemoryDataStore.cs
@@ -248,7 +248,7 @@ namespace CityInfoAPI.Data.Repositories
             return cities;
         }
 
-        public async Task<List<City>> GetPagedCities(int pageNumber, int pageSize)
+        public async Task<List<City>> GetPagedCities(int pageNumber, int pageSize, string name)
         {
             List<City> citiesWithoutPointsOfInterest = new List<City>();
             foreach (var completeCity in _cities)
@@ -263,6 +263,16 @@ namespace CityInfoAPI.Data.Repositories
                     PointsOfInterest = new List<PointOfInterest>()
                 };
                 citiesWithoutPointsOfInterest.Add(city);
+            }
+
+            // is user used a name filter
+            if (!string.IsNullOrEmpty(name))
+            {
+                return citiesWithoutPointsOfInterest.Where(c => c.Name.ToLower().Contains(name.ToLower()))
+                                                    .OrderBy(c => c.Name)
+                                                    .Skip((pageNumber - 1) * pageSize)
+                                                    .Take(pageSize)
+                                                    .ToList();
             }
 
             return citiesWithoutPointsOfInterest.OrderBy(c => c.Name).Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();

--- a/CityInfoAPI/CityInfoAPI.Data/Repositories/CityInfoSqlDataStore.cs
+++ b/CityInfoAPI/CityInfoAPI.Data/Repositories/CityInfoSqlDataStore.cs
@@ -27,8 +27,17 @@ namespace CityInfoAPI.Data.Repositories
             return cities;
         }
 
-        public Task<List<City>> GetPagedCities(int pageNumber, int pageSize)
+        public Task<List<City>> GetPagedCities(int pageNumber, int pageSize, string name)
         {
+            if (!string.IsNullOrEmpty(name))
+            {
+                return _cityInfoDbContext.Cities.Where(c => c.Name.Contains(name.ToLower()))
+                                                .OrderBy(c => c.Name)
+                                                .Skip((pageNumber - 1) * pageSize)
+                                                .Take(pageSize)
+                                                .ToListAsync();
+            }
+
             return _cityInfoDbContext.Cities.OrderBy(c => c.Name).Skip((pageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
         }
 

--- a/CityInfoAPI/CityInfoAPI.Data/Repositories/ICityInfoRespository.cs
+++ b/CityInfoAPI/CityInfoAPI.Data/Repositories/ICityInfoRespository.cs
@@ -10,7 +10,7 @@ namespace CityInfoAPI.Data.Repositories
         // cities
         Task<List<City>> GetCities();
 
-        Task<List<City>> GetPagedCities(int pageNumber, int pageSize);
+        Task<List<City>> GetPagedCities(int pageNumber, int pageSize, string name);
 
         Task<List<City>> GetCitiesWithPointsOfInterest();
 

--- a/CityInfoAPI/CityInfoAPI.Logic/Processors/CityProcessor.cs
+++ b/CityInfoAPI/CityInfoAPI.Logic/Processors/CityProcessor.cs
@@ -31,9 +31,9 @@ namespace CityInfoAPI.Logic.Processors
             return results;
         }
 
-        public async Task<List<CityWithoutPointsOfInterestDto>> GetPagedCities(int pageNumber, int pageSize)
+        public async Task<List<CityWithoutPointsOfInterestDto>> GetPagedCities(int pageNumber, int pageSize, string name)
         {
-            var pagedCityEntities = await _cityInfoRepository.GetPagedCities(pageNumber, pageSize);
+            var pagedCityEntities = await _cityInfoRepository.GetPagedCities(pageNumber, pageSize, name);
             var pagedCities = Mapper.Map<List<CityWithoutPointsOfInterestDto>>(pagedCityEntities);
             return pagedCities;
         }

--- a/CityInfoAPI/CityInfoAPI.Web/CityInfoAPI.Web.xml
+++ b/CityInfoAPI/CityInfoAPI.Web/CityInfoAPI.Web.xml
@@ -17,10 +17,10 @@
             <param name="httpContextAccessor">httpContextAccessor needed for LinkGenerator</param>
             <param name="linkGenerator">link generator</param>
         </member>
-        <member name="M:CityInfoAPI.Web.Controllers.CitiesController.GetPagedCities(CityInfoAPI.Web.Controllers.RequestHelpers.PagingParameters)">
+        <member name="M:CityInfoAPI.Web.Controllers.CitiesController.GetPagedCities(CityInfoAPI.Web.Controllers.RequestHelpers.RequestParameters)">
             <summary>gets collection of cities - results are paged</summary>
             <example>http://{domain}/api/v1.0/cities?pageNumber=1{n}_and_pageSize={n}</example>
-            <param name="pagingParameters"></param>
+            <param name="requestParameters"></param>
             <returns>collection of cities w/ no points of interest</returns>
             <response code="200">returns collection of cities</response>
         </member>

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/CitiesController.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/CitiesController.cs
@@ -55,30 +55,44 @@ namespace CityInfoAPI.Web.Controllers
 
         /// <summary>gets collection of cities - results are paged</summary>
         /// <example>http://{domain}/api/v1.0/cities?pageNumber=1{n}_and_pageSize={n}</example>
-        /// <param name="pagingParameters"></param>
+        /// <param name="requestParameters"></param>
         /// <returns>collection of cities w/ no points of interest</returns>
         /// <response code="200">returns collection of cities</response>
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesDefaultResponseType]
         [HttpGet("", Name = "GetPagedCities")]
-        public async Task<ActionResult<List<CityDto>>> GetPagedCities([FromQuery] PagingParameters pagingParameters)
+        public async Task<ActionResult<List<CityDto>>> GetPagedCities([FromQuery] RequestParameters requestParameters)
         {
             try
             {
                 // get only the cities we need
-                var pagedCities = await _cityProcessor.GetPagedCities(pagingParameters.PageNumber, pagingParameters.PageSize);
+                var pagedCities = await _cityProcessor.GetPagedCities(requestParameters.PageNumber, requestParameters.PageSize, requestParameters.Name);
 
                 // how many total pages do we have?
-                int allCities = _cityProcessor.GetAllCities().Result.Count();
-                int totalPages = (int)Math.Ceiling(allCities / (double)pagingParameters.PageSize);
+                int allPossibleCities = 0;
 
-                if (pagingParameters.PageNumber > totalPages)
+                // did they use a name filter? count all possible results
+                if (!string.IsNullOrEmpty(requestParameters.Name))
+                {
+                    var allCities = await _cityProcessor.GetAllCities();
+                    var filteredCities = allCities.Where(c => c.Name.ToLower().Contains(requestParameters.Name.ToLower()));
+                    allPossibleCities = filteredCities.Count();
+                }
+                else
+                {
+                    // count all
+                    allPossibleCities = _cityProcessor.GetAllCities().Result.Count();
+                }
+
+                int totalPages = (int)Math.Ceiling(allPossibleCities / (double)requestParameters.PageSize);
+
+                if (requestParameters.PageNumber > totalPages)
                 {
                     return BadRequest("You have requested more pages that are available.");
                 }
 
                 // build the meta-data to return in header
-                var metaData = MetaDataHelper.BuildCitiesMetaData(pagingParameters, _cityProcessor, _httpContextAccessor, _linkGenerator);
+                var metaData = MetaDataHelper.BuildCitiesMetaData(requestParameters, _cityProcessor, _httpContextAccessor, _linkGenerator);
 
                 // add as custom header
                 Response.Headers.Add("X-Pagination", Newtonsoft.Json.JsonConvert.SerializeObject(metaData));

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/CitiesController.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/CitiesController.cs
@@ -77,6 +77,12 @@ namespace CityInfoAPI.Web.Controllers
                     var allCities = await _cityProcessor.GetAllCities();
                     var filteredCities = allCities.Where(c => c.Name.ToLower().Contains(requestParameters.NameFilter.ToLower()));
                     allPossibleCities = filteredCities.Count();
+
+                    // bad filter was used
+                    if (allPossibleCities == 0)
+                    {
+                        return Ok($"No cities found with the name containing {requestParameters.NameFilter}.");
+                    }
                 }
                 else
                 {

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/CitiesController.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/CitiesController.cs
@@ -66,16 +66,16 @@ namespace CityInfoAPI.Web.Controllers
             try
             {
                 // get only the cities we need
-                var pagedCities = await _cityProcessor.GetPagedCities(requestParameters.PageNumber, requestParameters.PageSize, requestParameters.Name);
+                var pagedCities = await _cityProcessor.GetPagedCities(requestParameters.PageNumber, requestParameters.PageSize, requestParameters.NameFilter);
 
                 // how many total pages do we have?
                 int allPossibleCities = 0;
 
                 // did they use a name filter? count all possible results
-                if (!string.IsNullOrEmpty(requestParameters.Name))
+                if (!string.IsNullOrEmpty(requestParameters.NameFilter))
                 {
                     var allCities = await _cityProcessor.GetAllCities();
-                    var filteredCities = allCities.Where(c => c.Name.ToLower().Contains(requestParameters.Name.ToLower()));
+                    var filteredCities = allCities.Where(c => c.Name.ToLower().Contains(requestParameters.NameFilter.ToLower()));
                     allPossibleCities = filteredCities.Count();
                 }
                 else

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/RequestHelpers/RequestParameters.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/RequestHelpers/RequestParameters.cs
@@ -42,7 +42,7 @@
         }
 
         // name to filter by
-        public string Name { get; set; }
+        public string NameFilter { get; set; }
     }
 
     #pragma warning restore CS1591

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/RequestHelpers/RequestParameters.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/RequestHelpers/RequestParameters.cs
@@ -2,7 +2,7 @@
 {
     #pragma warning disable CS1591
 
-    public class PagingParameters
+    public class RequestParameters
     {
         private const int _minPageNumber = 1;
         private const int _defaultPageNumber = 1;
@@ -40,6 +40,9 @@
                 _pageSize = (_pageSize < _minPageSize) ? _minPageSize : _pageSize;
             }
         }
+
+        // name to filter by
+        public string Name { get; set; }
     }
 
     #pragma warning restore CS1591

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/ResponseHelpers/MetaDataHelper.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/ResponseHelpers/MetaDataHelper.cs
@@ -49,7 +49,7 @@ namespace CityInfoAPI.Web.Controllers.ResponseHelpers
                                                                 values: new {
                                                                                 pageNumber = requestParameters.PageNumber + 1,
                                                                                 pageSize = requestParameters.PageSize ,
-                                                                                name = requestParameters.Name
+                                                                    nameFilter = requestParameters.NameFilter
                                                                             });
                     case ResourceUriType.PreviousPage:
                         return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext,
@@ -58,8 +58,8 @@ namespace CityInfoAPI.Web.Controllers.ResponseHelpers
                                                                 values: new {
                                                                                 pageNumber = requestParameters.PageNumber - 1,
                                                                                 pageSize = requestParameters.PageSize,
-                                                                                name = requestParameters.Name
-                                                                            });
+                                                                    nameFilter = requestParameters.NameFilter
+                                                                });
                     default:
                         return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext,
                                                                 action: "GetPagedCities",
@@ -67,8 +67,8 @@ namespace CityInfoAPI.Web.Controllers.ResponseHelpers
                                                                 values: new {
                                                                                 pageNumber = requestParameters.PageNumber,
                                                                                 pageSize = requestParameters.PageSize,
-                                                                                name = requestParameters.Name
-                                                                            });
+                                                                                nameFilter = requestParameters.NameFilter
+                                                                });
                 }
             }
             catch (Exception exception)

--- a/CityInfoAPI/CityInfoAPI.Web/Controllers/ResponseHelpers/MetaDataHelper.cs
+++ b/CityInfoAPI/CityInfoAPI.Web/Controllers/ResponseHelpers/MetaDataHelper.cs
@@ -11,21 +11,21 @@ namespace CityInfoAPI.Web.Controllers.ResponseHelpers
 
     public static class MetaDataHelper
     {
-        public static PaginationMetaDataDto BuildCitiesMetaData(PagingParameters pagingParameters, CityProcessor _cityProcessor, IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
+        public static PaginationMetaDataDto BuildCitiesMetaData(RequestParameters requestParameters, CityProcessor _cityProcessor, IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
         {
             var allCities = _cityProcessor.GetAllCities().Result;
-            int totalPages = (int)Math.Ceiling(allCities.Count() / (double)pagingParameters.PageSize);
+            int totalPages = (int)Math.Ceiling(allCities.Count() / (double)requestParameters.PageSize);
             int totalCount = allCities.Count();
-            bool hasNextPage = pagingParameters.PageNumber < totalPages;
-            bool hasPrevPage = pagingParameters.PageNumber > 1;
-            string nextUrl = (pagingParameters.PageNumber < totalPages) ? CreateCitiesResourceUri(pagingParameters, ResourceUriType.NextPage, httpContextAccessor, linkGenerator) : string.Empty;
-            string prevUrl = (pagingParameters.PageNumber > 1) ? CreateCitiesResourceUri(pagingParameters, ResourceUriType.PreviousPage, httpContextAccessor, linkGenerator) : string.Empty;
+            bool hasNextPage = requestParameters.PageNumber < totalPages;
+            bool hasPrevPage = requestParameters.PageNumber > 1;
+            string nextUrl = (requestParameters.PageNumber < totalPages) ? CreateCitiesResourceUri(requestParameters, ResourceUriType.NextPage, httpContextAccessor, linkGenerator) : string.Empty;
+            string prevUrl = (requestParameters.PageNumber > 1) ? CreateCitiesResourceUri(requestParameters, ResourceUriType.PreviousPage, httpContextAccessor, linkGenerator) : string.Empty;
 
             PaginationMetaDataDto results = new PaginationMetaDataDto
             {
-                CurrentPage = pagingParameters.PageNumber,
+                CurrentPage = requestParameters.PageNumber,
                 TotalPages = totalPages,
-                PageSize = pagingParameters.PageSize,
+                PageSize = requestParameters.PageSize,
                 TotalCount = totalCount,
                 HasNextPage = hasNextPage,
                 HasPreviousPage = hasPrevPage,
@@ -36,18 +36,39 @@ namespace CityInfoAPI.Web.Controllers.ResponseHelpers
             return results;
         }
 
-        private static string CreateCitiesResourceUri(PagingParameters pagingParameters, ResourceUriType type, IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
+        private static string CreateCitiesResourceUri(RequestParameters requestParameters, ResourceUriType type, IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
         {
             try
             {
                 switch (type)
                 {
                     case ResourceUriType.NextPage:
-                        return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext, action: "GetPagedCities", controller: "Cities", values: new { pageNumber = pagingParameters.PageNumber + 1, pageSize = pagingParameters.PageSize });
+                        return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext,
+                                                                action: "GetPagedCities",
+                                                                controller: "Cities",
+                                                                values: new {
+                                                                                pageNumber = requestParameters.PageNumber + 1,
+                                                                                pageSize = requestParameters.PageSize ,
+                                                                                name = requestParameters.Name
+                                                                            });
                     case ResourceUriType.PreviousPage:
-                        return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext, action: "GetPagedCities", controller: "Cities", values: new { pageNumber = pagingParameters.PageNumber - 1, pageSize = pagingParameters.PageSize });
+                        return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext,
+                                                                action: "GetPagedCities",
+                                                                controller: "Cities",
+                                                                values: new {
+                                                                                pageNumber = requestParameters.PageNumber - 1,
+                                                                                pageSize = requestParameters.PageSize,
+                                                                                name = requestParameters.Name
+                                                                            });
                     default:
-                        return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext, action: "GetPagedCities", controller: "Cities", values: new { pageNumber = pagingParameters.PageNumber, pageSize = pagingParameters.PageSize });
+                        return linkGenerator.GetUriByAction(httpContextAccessor.HttpContext,
+                                                                action: "GetPagedCities",
+                                                                controller: "Cities",
+                                                                values: new {
+                                                                                pageNumber = requestParameters.PageNumber,
+                                                                                pageSize = requestParameters.PageSize,
+                                                                                name = requestParameters.Name
+                                                                            });
                 }
             }
             catch (Exception exception)

--- a/Postman-Collection/Cities-API-Tutorial.postman_collection.json
+++ b/Postman-Collection/Cities-API-Tutorial.postman_collection.json
@@ -303,12 +303,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "<CityCreateDto xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://schemas.datacontract.org/2004/07/CityInfoAPI.Dtos.Models\">\n    <Description>Description for Alpha City</Description>\n    <Name>New Alpha City</Name>\n    <PointsOfInterest>\n        <PointOfInterestCreateRequestDto>\n            <Description>Description for location 1</Description>\n            <Name>Location 1</Name>\n        </PointOfInterestCreateRequestDto>\n        <PointOfInterestCreateRequestDto>\n            <Description>Description for location 2</Description>\n            <Name>Location 2</Name>\n        </PointOfInterestCreateRequestDto>\n    </PointsOfInterest>\n</CityCreateDto>",
-					"options": {
-						"raw": {
-							"language": "xml"
-						}
-					}
+					"raw": "<CityCreateDto xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://schemas.datacontract.org/2004/07/CityInfoAPI.Dtos.Models\">\n    <Description>Description for Alpha City</Description>\n    <Name>New Alpha City</Name>\n    <PointsOfInterest>\n        <PointOfInterestCreateRequestDto>\n            <Description>Description for location 1</Description>\n            <Name>Location 1</Name>\n        </PointOfInterestCreateRequestDto>\n        <PointOfInterestCreateRequestDto>\n            <Description>Description for location 2</Description>\n            <Name>Location 2</Name>\n        </PointOfInterestCreateRequestDto>\n    </PointsOfInterest>\n</CityCreateDto>"
 				},
 				"url": {
 					"raw": "{{domain-local}}/api/v1.0/cities",
@@ -571,6 +566,45 @@
 						"38276231-1918-452d-a3e9-6f50873a95d2",
 						"pointsofinterest",
 						"07c2f263-8afe-4028-8c0e-7d4657ff66fc"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET Cities (with paging and name filter)",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{domain-local}}/api/v1.0/cities?pageNumber=1&pageSize=10&name=chica",
+					"host": [
+						"{{domain-local}}"
+					],
+					"path": [
+						"api",
+						"v1.0",
+						"cities"
+					],
+					"query": [
+						{
+							"key": "pageNumber",
+							"value": "1"
+						},
+						{
+							"key": "pageSize",
+							"value": "10"
+						},
+						{
+							"key": "name",
+							"value": "chica"
+						}
 					]
 				}
 			},

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ Valid options:
 ##### Get Cities 
 [https://city-info-api-demo.azurewebsites.net/api/v1.0/cities?pagenumber={n}&pagesize={n}](https://city-info-api-demo.azurewebsites.net/api/v1.0/cities?pagenumber={n}&pagesize={n} "https://city-info-api-demo.azurewebsites.net/api/v1.0/cities?pagenumber={n}&pagesize={n}")   
 `GET`   
-This resource with return a collection of all cities but does not show you their associated points of interest. Furthermore, it implements paging and you must specify the page number (`pagenumber`) you are requesting and number of results per page (`pagesize`) in the querystring. 
+This resource with return a collection of all cities but does not show you their associated points of interest. 
+
+**Paging:**
+This endpoint implements paging and you **must** specify the page number (`pagenumber`) you are requesting **and** the number of results per page (`pagesize`) in the querystring. These two parameters are required.
 
 Both parameters have default values should the consumer forget to provide them and minimum and maximum limits should the consumer exceed those limits.  If the limits are exceed, it will will fall back to default values.
 
@@ -80,7 +83,14 @@ Both parameters have default values should the consumer forget to provide them a
 | pageSize   | 10      | 1         | 10        |
 
 
-The Response Header will provide the requestor helpful information in a custom item known as `X-Pagination`.  It returns links to the next page (if applicable), previous page (if applicable), and total city count.    
+**Name Filtering:** 
+an optional parameter you can provide in this request is a Name filter which looks like this:
+`http://city-info-api-demo.azurewebsites.net/api/v1.0/cities?pageNumber=1&pageSize=10&name=chica`
+
+In this example, it will return up to 10 results per page for any city with a name containing "chica" such as Chicago.  It is not case-sensitive.
+
+
+The Response Header will provide the requestor helpful information in a custom item known as `X-Pagination`.  It returns links to the next page (if applicable), previous page (if applicable), the name filter (if used), and total city count.    
 ![](https://github.com/RedBirdOBX/City-Info-API-Demo/blob/master/Images/x-pagination.png)
 
 
@@ -495,4 +505,4 @@ Add custom paging meta data to the response header.  Tell consumer if there is a
 
 **1.10.0**  
 2.10.2020
-Filtering
+- Name filtering was introduced. You can now filter on city names.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The City Info Demo API
   
 ----------
-*Version 1.9.1*
+*Version 1.10.0*
 
 ## Summary
 Welcome to the City Info Demo API. Imagine that you were developing for some kind of travel site and one of the requirements was you needed to be able to ask for a complete listing of cities; ask for any given city by it's ID and, if specifically asked for, you needed to be able to provide all the "touristy" things to do for that specified city (landmarks, parks, restaurants, and so on).  
@@ -493,3 +493,6 @@ Added new resources:
 2.6.2020  
 Add custom paging meta data to the response header.  Tell consumer if there is a previous page, if there is a next page, and how many total results there are. Custom Header item is known as `X-Pagination`.
 
+**1.10.0**  
+2.10.2020
+Filtering


### PR DESCRIPTION
# City Info API Demo Pull Request #


## Intent ##
To provide Name Filtering on the `GetCities` endpoint.  



## Changes Summary ##
Now a user can provide a filter on the city name and limit the results.  For example: 

`/api/v1.0/cities?pageNumber=1&pageSize=10&nameFilter=chica`


## Type of Changes ##
- [x] New Feature  :gift:
- [ ] Maintenance /  Clean up 
- [ ] Refactoring 
- [ ] Defect :name_badge:  


## UAT Checklist ##
- [x] Code builds locally
- [ ] Style-cop/Linters used
- [x] Local tests performed

## How to Test ##
Can you still make a request for Cities without providing a name filter and get results?
Can you provide a valid name filter like "chic" and get back only cities containing "chic"?
Can you provide a bad filter like `nameFilter=xxx` and get back no results and a friendly message?

Yes to all three questions == success.


